### PR TITLE
Include MongoDB plus Game & Rating classes

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -19,6 +19,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/backend/src/main/java/com/gleam/backend/controller/GameController.java
+++ b/backend/src/main/java/com/gleam/backend/controller/GameController.java
@@ -8,9 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/games")
@@ -26,22 +24,18 @@ public class GameController {
 
     @GetMapping("/getGamesCount")
     public long getGamesCount(){
-        return getAllGames().size();
+        return gameService.getGamesCount();
     }
 
     @GetMapping("/getGamesWithPrefix")
     public List<Game> getGamesWithPrefix(@RequestParam(value = "prefix") String prefix)
     {
-        return getAllGames().stream()
-                .filter(game -> game.getTitle().toLowerCase().startsWith(prefix.toLowerCase()))
-                .collect(Collectors.toList());
+        return gameService.getGamesWithPrefix(prefix);
     }
 
     @GetMapping("/getGameWithPrefix")
     public Game getGameWithPrefix(@RequestParam(value = "prefix") String prefix)
     {
-        return getGamesWithPrefix(prefix).stream()
-                .min(Comparator.comparing(Game::getTitle, String.CASE_INSENSITIVE_ORDER))
-                .orElse(null);
+        return gameService.getGameWithPrefix(prefix);
     }
 }

--- a/backend/src/main/java/com/gleam/backend/controller/GameController.java
+++ b/backend/src/main/java/com/gleam/backend/controller/GameController.java
@@ -1,0 +1,47 @@
+package com.gleam.backend.controller;
+
+import com.gleam.backend.model.Game;
+import com.gleam.backend.service.GameService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/games")
+public class GameController {
+
+    @Autowired
+    private GameService gameService;
+
+    @GetMapping("/getAllGames")
+    public List<Game> getAllGames() {
+        return gameService.getAllGames();
+    }
+
+    @GetMapping("/getGamesCount")
+    public long getGamesCount(){
+        return getAllGames().size();
+    }
+
+    @GetMapping("/getGamesWithPrefix")
+    public List<Game> getGamesWithPrefix(@RequestParam(value = "prefix") String prefix)
+    {
+        return getAllGames().stream()
+                .filter(game -> game.getTitle().toLowerCase().startsWith(prefix.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/getGameWithPrefix")
+    public Game getGameWithPrefix(@RequestParam(value = "prefix") String prefix)
+    {
+        return getGamesWithPrefix(prefix).stream()
+                .min(Comparator.comparing(Game::getTitle, String.CASE_INSENSITIVE_ORDER))
+                .orElse(null);
+    }
+}

--- a/backend/src/main/java/com/gleam/backend/controller/LoginController.java
+++ b/backend/src/main/java/com/gleam/backend/controller/LoginController.java
@@ -1,5 +1,6 @@
-package com.gleam.backend;
+package com.gleam.backend.controller;
 
+import com.gleam.backend.Login;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/backend/src/main/java/com/gleam/backend/model/Game.java
+++ b/backend/src/main/java/com/gleam/backend/model/Game.java
@@ -1,0 +1,48 @@
+package com.gleam.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.data.annotation.Id;
+
+import java.util.Date;
+import java.util.List;
+
+public class Game {
+    @Id private String id;
+    private String title;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private Date releaseDate;
+    private String developer;
+    private List<Rating> ratings;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Date getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(Date releaseDate) {
+        this.releaseDate = releaseDate;
+    }
+
+    public String getDeveloper() {
+        return developer;
+    }
+
+    public void setDeveloper(String developer) {
+        this.developer = developer;
+    }
+
+    public List<Rating> getRatings() {
+        return ratings;
+    }
+
+    public void setRatings(List<Rating> ratings) {
+        this.ratings = ratings;
+    }
+}

--- a/backend/src/main/java/com/gleam/backend/model/Rating.java
+++ b/backend/src/main/java/com/gleam/backend/model/Rating.java
@@ -1,0 +1,22 @@
+package com.gleam.backend.model;
+
+public class Rating {
+    private int rating;
+    private String comment;
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        this.rating = rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+}

--- a/backend/src/main/java/com/gleam/backend/repository/GameRepository.java
+++ b/backend/src/main/java/com/gleam/backend/repository/GameRepository.java
@@ -1,0 +1,9 @@
+package com.gleam.backend.repository;
+
+import com.gleam.backend.model.Game;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface GameRepository extends MongoRepository<Game, String> {
+}

--- a/backend/src/main/java/com/gleam/backend/repository/RatingRepository.java
+++ b/backend/src/main/java/com/gleam/backend/repository/RatingRepository.java
@@ -1,0 +1,9 @@
+package com.gleam.backend.repository;
+
+import com.gleam.backend.model.Rating;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface RatingRepository extends MongoRepository<Rating, String> {
+}

--- a/backend/src/main/java/com/gleam/backend/service/GameService.java
+++ b/backend/src/main/java/com/gleam/backend/service/GameService.java
@@ -1,0 +1,19 @@
+package com.gleam.backend.service;
+
+import com.gleam.backend.model.Game;
+import com.gleam.backend.repository.GameRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GameService {
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    public List<Game> getAllGames() {
+        return gameRepository.findAll();
+    }
+}

--- a/backend/src/main/java/com/gleam/backend/service/GameService.java
+++ b/backend/src/main/java/com/gleam/backend/service/GameService.java
@@ -5,7 +5,9 @@ import com.gleam.backend.repository.GameRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class GameService {
@@ -15,5 +17,23 @@ public class GameService {
 
     public List<Game> getAllGames() {
         return gameRepository.findAll();
+    }
+
+    public long getGamesCount(){
+        return getAllGames().size();
+    }
+
+    public List<Game> getGamesWithPrefix(String prefix)
+    {
+        return getAllGames().stream()
+                .filter(game -> game.getTitle().toLowerCase().startsWith(prefix.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+
+    public Game getGameWithPrefix( String prefix)
+    {
+        return getGamesWithPrefix(prefix).stream()
+                .min(Comparator.comparing(Game::getTitle, String.CASE_INSENSITIVE_ORDER))
+                .orElse(null);
     }
 }


### PR DESCRIPTION
Added basic Game & Rating domain objects including repositories, storing first entities in a mongoDb docker container running in WSL2.

Solves:

- https://lise.atlassian.net/browse/UPDF-124
- https://lise.atlassian.net/browse/UPDF-125
- https://lise.atlassian.net/browse/UPDF-126