### PR TITLE
Refactor dialog management

### DIFF
--- a/frontend/src/components/GameEntry.tsx
+++ b/frontend/src/components/GameEntry.tsx
@@ -20,8 +20,8 @@ const StyledBadge = styled(Badge)<BadgeProps>(() => ({
 }));
 
 const GameEntry: React.FC<GameEntryProps> = ({game, onLike}) => {
-    const {openDialog, openInfo} = useDialog();
-    if (!game || !openDialog || !openInfo) {
+    const {openDialog} = useDialog();
+    if (!game || !openDialog) {
         return (
             <div className="gameCard">
                 <p>Game not found</p>
@@ -79,7 +79,7 @@ const GameEntry: React.FC<GameEntryProps> = ({game, onLike}) => {
 
                 openDialog('gameDetails', gameDetailsProps);
             } catch (error) {
-                openInfo("Game not found", error.message);
+                openDialog('info', {title: "Game not found", message: error.message});
             }
         }
 

--- a/frontend/src/components/dialogs/DialogContext.tsx
+++ b/frontend/src/components/dialogs/DialogContext.tsx
@@ -13,7 +13,6 @@ interface DialogContextProps {
     dialogType: DialogType | null;
     dialogProps: DialogPropsMap[DialogType] | null;
     openDialog: <T extends DialogType>(type: T, props: DialogPropsMap[T]) => void;
-    openInfo: (title: string, message: string) => void;
     closeDialog: () => void;
 }
 
@@ -28,23 +27,13 @@ export const DialogProvider: React.FC<{ children: ReactNode }> = ({children}) =>
         setDialogProps(props);
     };
 
-    const openInfo = (title: string, message: string) => {
-        setDialogType('info')
-
-        const infoProps: InfoDialogProps = {
-            title: title,
-            message: message
-        }
-        setDialogProps(infoProps);
-    }
-
     const closeDialog = () => {
         setDialogType(null);
         setDialogProps(null);
     };
 
     return (
-        <DialogContext.Provider value={{dialogType, dialogProps, openDialog, openInfo, closeDialog}}>
+        <DialogContext.Provider value={{dialogType, dialogProps, openDialog, closeDialog}}>
             {children}
         </DialogContext.Provider>
     );

--- a/frontend/src/components/dialogs/GameDetailsDialog.tsx
+++ b/frontend/src/components/dialogs/GameDetailsDialog.tsx
@@ -28,34 +28,28 @@ const GameDetailsDialog: React.FC = () => {
         );
     }
 
-    const {
-        title,
-        description,
-        releaseDate,
-        developerName,
-        score,
-        youtubeTrailer
-    } = dialogProps as GameDetailsDialogProps;
-
+    const gameDetailsProps = dialogProps as GameDetailsDialogProps;
 
     return (
-        <Dialog open={!!title} onClose={closeDialog} maxWidth="md" fullWidth>
+        <Dialog open={true} onClose={closeDialog} maxWidth="md" fullWidth>
             <ReactPlayer
-                url={youtubeTrailer}
+                url={gameDetailsProps.youtubeTrailer}
                 playing={true}
                 width="100%"
                 height="400px"
                 loop={true}
             />
             <DialogTitle>
-                {title}
+                {gameDetailsProps.title}
             </DialogTitle>
             <DialogContent>
                 <Stack spacing={2}>
-                    <Typography variant="body1">{description}</Typography>
-                    <Typography variant="body2"><strong>Erscheinungsjahr:</strong> {releaseDate}</Typography>
-                    <Typography variant="body2"><strong>Entwickler:</strong> {developerName}</Typography>
-                    <Typography variant="body2"><strong>Glam Score:</strong> {score}</Typography>
+                    <Typography variant="body1">{gameDetailsProps.description}</Typography>
+                    <Typography variant="body2"><strong>Erscheinungsjahr:</strong> {gameDetailsProps.releaseDate}
+                    </Typography>
+                    <Typography variant="body2"><strong>Entwickler:</strong> {gameDetailsProps.developerName}
+                    </Typography>
+                    <Typography variant="body2"><strong>Glam Score:</strong> {gameDetailsProps.score}</Typography>
                 </Stack>
             </DialogContent>
         </Dialog>


### PR DESCRIPTION
Mir fällt grad erst auf, dass ich die Descriptions immer auf Englisch geschrieben habe, während wir in den Kommentaren auf Deutsch reden. Der Einfachheit halber ändere ich das nun auch auf Deutsch :) 

Ich habe mich beim Refactor dazu entschieden den DialogContext doch zu behalten und nicht für jeden Dialogtyp einen eigenen zu erstellen. Der Hauptgrund war, dass der React Context Provider im wesentlich um andere children herumgewrappt werden, so wie ich das verstanden habe. Mit zunehmenden Dialogtypen und Providern würde der Tree immer tiefer werden. Also:

![image](https://github.com/dforstmaierLise/gleam/assets/171693026/102e047a-512a-4120-9fe5-f7576df8c38e)

Angenommen ich täusche mich hier nicht, wäre das keine schön skalierbare Lösung.

Aber:

Das `openInfo` habe ich wieder entfernt, dadurch ist der DialogContext nun wieder deutlich generischer und hoffentlich einfacher zuverstehen. Zusätzlich habe ich einen anderen Syntax gefunden mit dem ich so zufrieden bin, dass ich eine shortcut Version gar nicht mehr brauche: `openDialog('info', {title: "Game not found", message: error.message});`

Lediglich in den Dialog-Komponenten selbst ist es noch etwas unperfekt, dass man die übergebenen Props casten muss. Anstelle aber jede einzelne Variable zu definieren, geht auch folgendes: 
`const gameDetailsProps = dialogProps as GameDetailsDialogProps;`

Ganz prinzipiell bin ich mit dieser Lösung zufrieden, da sie ungefähr so funktioniert und so skaliert wie ich es aus meinen vergangenen Projekten gewohnt war. Gut möglich, dass sie nach wie vor etwas unorthodox ist, aber denke für dieses Projekt ist das wohl in Ordnung. Ich hatte nach alternativen Lösungen gesucht, da wollte mir aber keine so wirklich gefallen - und der Aufwand für den Change in diesem PR war so verlockend klein, dass ich mich dafür entschieden habe. Fällt dir noch etwas auf das grundlegend ein Problem darstellt oder hast du noch weitere Ideen wie ich es doch realitätsnaher implementieren könnte?

